### PR TITLE
travis: update go version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
-  - 1.9
+  - 1.9.x
 script:
   - make


### PR DESCRIPTION
1.9.x match latest go 1.9 subversion (1.9.1. today, 1.9.2 in very near future)