### PR TITLE
Using an interface instead of a list of strings for data source

### DIFF
--- a/fuzzy.go
+++ b/fuzzy.go
@@ -41,19 +41,21 @@ func (a Matches) Len() int           { return len(a) }
 func (a Matches) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a Matches) Less(i, j int) bool { return a[i].score >= a[j].score }
 
-// Abstract source of a list of strings
+// Source represents an abstract source of a list of strings
 type Source interface {
 	String(i int) string
 	Len() int
 }
 
-// List of strings as a Source
+// StringSource is a list of strings as a Source
 type StringSource []string
 
+// String implementation for list of strings
 func (ss StringSource) String(i int) string {
 	return ss[i]
 }
 
+// Len implementation for list of strings
 func (ss StringSource) Len() int { return len(ss) }
 
 /*
@@ -78,6 +80,10 @@ func Find(pattern string, data []string) Matches {
 	return FindFrom(pattern, StringSource(data))
 }
 
+/*
+FindFrom is an alternative implementation of Find using a Source
+instead of a list of strings.
+*/
 func FindFrom(pattern string, data Source) Matches {
 	if len(pattern) == 0 {
 		return nil

--- a/fuzzy.go
+++ b/fuzzy.go
@@ -41,6 +41,21 @@ func (a Matches) Len() int           { return len(a) }
 func (a Matches) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a Matches) Less(i, j int) bool { return a[i].score >= a[j].score }
 
+// Abstract source of a list of strings
+type Source interface {
+	String(i int) string
+	Len() int
+}
+
+// List of strings as a Source
+type StringSource []string
+
+func (ss StringSource) String(i int) string {
+	return ss[i]
+}
+
+func (ss StringSource) Len() int { return len(ss) }
+
 /*
 Find looks up pattern in data and returns matches
 in descending order of match quality. Match quality
@@ -60,15 +75,19 @@ Penalties are applied for every character in the search string that wasn't match
 characters upto the first match.
 */
 func Find(pattern string, data []string) Matches {
+	return FindFrom(pattern, StringSource(data))
+}
+
+func FindFrom(pattern string, data Source) Matches {
 	if len(pattern) == 0 {
 		return nil
 	}
 	runes := []rune(pattern)
 	var matches Matches
 	var matchedIndexes []int
-	for i := 0; i < len(data); i++ {
+	for i := 0; i < data.Len(); i++ {
 		var match Match
-		match.Str = data[i]
+		match.Str = data.String(i)
 		match.Index = i
 		if matchedIndexes != nil {
 			match.MatchedIndexes = matchedIndexes
@@ -82,10 +101,10 @@ func Find(pattern string, data []string) Matches {
 		currAdjacentMatchBonus := 0
 		var last rune
 		var lastIndex int
-		nextc, nextSize := utf8.DecodeRuneInString(data[i])
+		nextc, nextSize := utf8.DecodeRuneInString(data.String(i))
 		var candidate rune
 		var candidateSize int
-		for j := 0; j < len(data[i]); j += candidateSize {
+		for j := 0; j < len(data.String(i)); j += candidateSize {
 			candidate, candidateSize = nextc, nextSize
 			if equalFold(candidate, runes[patternIndex]) {
 				score = 0
@@ -115,11 +134,11 @@ func Find(pattern string, data []string) Matches {
 			if patternIndex < len(runes)-1 {
 				nextp = runes[patternIndex+1]
 			}
-			if j+candidateSize < len(data[i]) {
-				if data[i][j+candidateSize] < utf8.RuneSelf { // Fast path for ASCII
-					nextc, nextSize = rune(data[i][j+candidateSize]), 1
+			if j+candidateSize < len(data.String(i)) {
+				if data.String(i)[j+candidateSize] < utf8.RuneSelf { // Fast path for ASCII
+					nextc, nextSize = rune(data.String(i)[j+candidateSize]), 1
 				} else {
-					nextc, nextSize = utf8.DecodeRuneInString(data[i][j+candidateSize:])
+					nextc, nextSize = utf8.DecodeRuneInString(data.String(i)[j+candidateSize:])
 				}
 			} else {
 				nextc, nextSize = 0, 0
@@ -146,7 +165,7 @@ func Find(pattern string, data []string) Matches {
 			last = candidate
 		}
 		// apply penalty for each unmatched character
-		penalty := len(match.MatchedIndexes) - len(data[i])
+		penalty := len(match.MatchedIndexes) - len(data.String(i))
 		match.score += penalty
 		if len(match.MatchedIndexes) == len(runes) {
 			matches = append(matches, match)


### PR DESCRIPTION
I'd like to offer a possible improvement to the API of Find. In the style of the sort.Sort interface, I've put an interface between the data source and Find(). The motivation is to allow using Find() for lists of things that might not be strings. In my particular case, I had an array of structs that included a Name field. I was able to use Find (or the renamed FindFrom) like this:

    type MyStruct struct {
        SomeField string
        SomeID int64
        Name string
    }

    type MyStructList []*MyStruct

    func (a MyStructList) String(i int) string { return a[i].Name }
    func (a MyStructList) Len() int { return len(a[i]) }

    var thingList []*MyString

    // Do something to fill thingList

    matches := fuzzy.FindFrom(pattern, MyStructList(thingList))

It strikes me as a much more general way of passing data to a function, rather than limiting the package to only work for lists of strings. 