### PR TITLE
Feature interfaces

### DIFF
--- a/fuzzy.go
+++ b/fuzzy.go
@@ -94,7 +94,7 @@ func Find(pattern string, data []string) Matches {
 	return FindFrom(pattern, stringSource(data))
 }
 
-// Same as Find but takes *interface{} array, uses fmt.Sprint to get string value
+// FindInterface is same as Find but takes *interface{} array, uses fmt.Sprint to get string value
 func FindInterface(pattern string, data []*interface{}) Matches {
 	return FindFrom(pattern, interfaceSource(data))
 }


### PR DESCRIPTION
Hi, I added a new function that takes `[]*interface{}` as input and extracts the string from it with `fmt.Sprint()` function. 

I added `val *interface{}` to `match` struct, it returns `nil` if you are searching for a string, but on the other hand, if you are searching for `*interface{}` it will return the actual value.