### PR TITLE
`FindFrom` respects original ordering

### DIFF
--- a/fuzzy.go
+++ b/fuzzy.go
@@ -40,7 +40,7 @@ type Matches []Match
 
 func (a Matches) Len() int           { return len(a) }
 func (a Matches) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a Matches) Less(i, j int) bool { return a[i].Score >= a[j].Score }
+func (a Matches) Less(i, j int) bool { return a[i].Score > a[j].Score }
 
 // Source represents an abstract source of a list of strings. Source must be iterable type such as a slice.
 // The source will be iterated over till Len() with String(i) being called for each element where i is the

--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -1,13 +1,15 @@
 package fuzzy_test
 
 import (
-	"fmt"
 	"os"
-	"strings"
 	"testing"
-	"time"
 
 	"github.com/sahilm/fuzzy"
+
+	"strings"
+
+	"fmt"
+	"time"
 
 	"github.com/kylelemons/godebug/pretty"
 )
@@ -180,6 +182,7 @@ func TestFindWithRealworldData(t *testing.T) {
 			numMatches int
 			filenames  []string
 		}{
+
 			{
 				"ue4", 4, []string{
 					"UE4Build.cs",
@@ -232,6 +235,7 @@ func TestFindWithRealworldData(t *testing.T) {
 			numMatches int
 			filenames  []string
 		}{
+
 			{
 				"make", 4, []string{
 					"make",
@@ -274,6 +278,7 @@ func TestFindWithRealworldData(t *testing.T) {
 			}
 		}
 	})
+
 }
 
 func BenchmarkFind(b *testing.B) {

--- a/fuzzy_test.go
+++ b/fuzzy_test.go
@@ -1,15 +1,13 @@
 package fuzzy_test
 
 import (
+	"fmt"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/sahilm/fuzzy"
-
-	"strings"
-
-	"fmt"
-	"time"
 
 	"github.com/kylelemons/godebug/pretty"
 )
@@ -158,13 +156,13 @@ func TestFindFromSource(t *testing.T) {
 	}
 	want := fuzzy.Matches{
 		{
-			Str:            "Allie",
-			Index:          2,
+			Str:            "Alice",
+			Index:          0,
 			MatchedIndexes: []int{0, 1},
 			Score:          12,
 		}, {
-			Str:            "Alice",
-			Index:          0,
+			Str:            "Allie",
+			Index:          2,
 			MatchedIndexes: []int{0, 1},
 			Score:          12,
 		},
@@ -182,20 +180,19 @@ func TestFindWithRealworldData(t *testing.T) {
 			numMatches int
 			filenames  []string
 		}{
-
 			{
 				"ue4", 4, []string{
-					"UE4Game.cpp",
 					"UE4Build.cs",
-					"UE4Game.Build.cs",
+					"UE4Game.cpp",
 					"UE4BuildUtils.cs",
+					"UE4Game.Build.cs",
 				},
 			},
 			{
 				"lll", 3, []string{
 					"LogFileLogger.cs",
-					"LockFreeListImpl.h",
 					"LevelExporterLOD.h",
+					"LockFreeListImpl.h",
 				},
 			},
 			{
@@ -235,7 +232,6 @@ func TestFindWithRealworldData(t *testing.T) {
 			numMatches int
 			filenames  []string
 		}{
-
 			{
 				"make", 4, []string{
 					"make",
@@ -246,10 +242,10 @@ func TestFindWithRealworldData(t *testing.T) {
 			},
 			{
 				"alsa", 4, []string{
-					"alsa.h",
 					"alsa.c",
+					"alsa.h",
 					"aw2-alsa.c",
-					"cx88-alsa.c",
+					"ivtv-alsa.h",
 				},
 			},
 		}
@@ -278,7 +274,6 @@ func TestFindWithRealworldData(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 func BenchmarkFind(b *testing.B) {


### PR DESCRIPTION
Fixes #27 

Explanation of the problem is stated in the issue above.

With the test cases I verified:
- `UE4Build.cs` is above `UE4Game.cpp` and `UE4BuildUtils.cs` is above `UE4Game.Build.cs`
- Also, `ivtv-alsa.h` is on line 31887 and `cx88-alsa.c` is on line 32099 so top 4 result should be replaced by `ivtv-alsa.h`